### PR TITLE
Added support for attribute by name

### DIFF
--- a/src/pyxmenu/item/attribute/__base__.py
+++ b/src/pyxmenu/item/attribute/__base__.py
@@ -33,8 +33,11 @@ class AttributeName(Enum):
     DISABLED = 'disabled'
 
     @classmethod
-    def _missing_(cls, value):
-        return cls.INVALID
+    def _missing_(cls, value: str):
+        try:
+            return getattr(cls, value.upper())
+        except AttributeError:
+            return cls.INVALID
 
 
 class Attribute(abc.ABC):


### PR DESCRIPTION
When an attribute name is missing try load it by the attribute's pythonic name as a fallback before returning invalid

fixes #5 